### PR TITLE
fix: actions only support node12 and node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
   autofix_command:
     description: 'post-update linting autofix code'
 runs:
-  using: 'node14'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node14' is not supported, use 'docker', 'node12' or 'node16' instead.')