### PR TITLE
chore: pin publish to node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 16
 
     - run: npm ci
     - run: |

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0]
+  }
 };


### PR DESCRIPTION
```
Command failed: ncc build src/action.js -o dist && git add -A dist
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:69:19)
    at Object.createHash (node:crypto:133:10)
    at hashOf (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:3:58216)
    at module.exports (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/index.js.cache.js:3:60642)
    at runCmd (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:47355)
    at 819 (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:44227)
    at __webpack_require__ (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:169)
    at startup (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:339)
    at module.exports.8 (/home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:371)
    at /home/runner/work/ember-cli-update-action/ember-cli-update-action/node_modules/@zeit/ncc/dist/ncc/cli.js.cache.js:1:381 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```