### PR TITLE
fix: verbose is now string instead of bool

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ async function spawn(bin, args = [], options) {
 
   let ps = execa(bin, args, {
     stdio: ['ignore', 'pipe', 'inherit'],
-    verbose: true,
+    verbose: 'full',
     ...options
   });
 
@@ -21,7 +21,7 @@ async function exec(command, options) {
 
   let ps = execaCommand(command, {
     stdio: ['ignore', 'pipe', 'inherit'],
-    verbose: true,
+    verbose: 'full',
     ...options
   });
 


### PR DESCRIPTION
Fixes the error `The "verbose: true" option was renamed to "verbose: 'short'".`